### PR TITLE
fix-pdf-distortion and images duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # POC [doc88.com](https://doc88.com) Downloader
 
-This is a POC downloader of documents from [doc88.com](https://doc88.com). It saves pages of a given document as PNGs or JPEGs. It doesn't have any dependencies — it's a bit of JavaScript that you paste into Developer Tools' Console. It was tested in Chrome and Firefox.
+This is a POC downloader of documents from [doc88.com](https://doc88.com). It saves pages of a given document as PNGs or JPEGs. It doesn't have any dependencies — it's a bit of JavaScript that you can paste into Developer Tools' Console or create a Bookmark. It was tested in Chrome and Firefox.
 
 Then, having pages saved as images, a searchable PDF can be reconstructed from them.
 
 ## Step 1: Save pages of a document as images
-
-### Option A: Bookmark
 
 Create a browser bookmark, pasting content of [this file](bookmark.min.js) (exactly as it is) in its URL field.
 
@@ -36,11 +34,3 @@ Under Linux you can easily convert downloaded images back to a PDF.
     ./convert-images-to-pdf.sh image-directory output.pdf
     ```
    Run it with `-h` argument for help.
-
-### Troubleshooting
-
-If you see errors from ImageMagick with the message "attempt to perform an operation not allowed by the security policy 'PDF'", see [this StackOverflow question](https://stackoverflow.com/q/52998331/1820695) and answers for a likely quick fix.
-
-## Developing
-
-1. Run `build-bookmark.sh` to update minified bookmark code in `bookmark.min.js`.

--- a/README.md
+++ b/README.md
@@ -18,56 +18,14 @@ From now on, clicking the bookmark on a document page will capture all pages as 
 > You can assess the progress of the process in doc88's page selector (e.g. "17 / 42").  
 > Check that all desired pages were captured correctly.
 
-### Option B: Manual (finer control over the process)
-
-1. Navigate to the desired document in your browser.
-2. Make sure browser's zoom level is set to 100% — based on some tests it seems that zoom levels lower than 100% can result in lower quality of captured pages.
-3. Open Developer Tools (e.g. press <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>I</kbd>).
-4. Switch to JavaScript Console.
-5. Paste [this JavaScript](downloadPages.js) in Console and confirm with <kbd>Enter</kbd>.
-6. Type the following in Console and hit <kbd>Enter</kbd>:
-    ```javascript
-    downloadPages()
-    ```
-   This will capture and bundle all the pages in a ZIP file.  
-   Pages will be automatically preloaded and captured one by one.
-
-See [options](#options) section below for options.
-
-> [!IMPORTANT]  
-> Don't interact with the browser during the process.  
-> Be patient, especially with large documents containing hundreds of pages.  
-> Wait until it ends, printing `Finished downloading pages` in the Console.  
-> Check that all desired pages were captured correctly.
-
-
-#### Options
-
-`downloadPages` function takes an optional options object:
-
-```javascript
-downloadPages({fromPage: 2, toPage: 10, quality: 0.8, imageNamePrefix: 'temp_'})
-```
-
-Possible options are:
-
-1. `fromPage` – first page in range to be downloaded; number; default is `1`
-2. `toPage` – last page in range to be downloaded; number; default is total number of pages in the document
-3. `format` – downloaded image format; string; either `'jpg'` or `'png'`; default is `'jpg'`
-4. `quality` – quality of images; applicable when `format` is `'jpg'`; number between `0` and `1`; default is `0.9`
-5. `imageNamePrefix` – prefix for names of downloaded images; string; default is `'page'` (resulting in downloaded file names e.g.: `page001.jpg`, `page002.jpg`, etc. assuming `format` is `'jpg'`)
-6. `archive` – type of archive to put the captured images in; string; either `'zip'` or `'none'`; default is `'zip'`; `'none'` will result in each image downloaded as a separate file
-
-> [!NOTE]  
-> In case of Chrome, if you set `archive` to `none`, the first time you download pages you may see a popup stating that "This site is attempting to download multiple files". You have to allow it, as with this option each page will be downloaded as a separate file.
 
 ## Step 2: Converting images back to a PDF
 
 Under Linux you can easily convert downloaded images back to a PDF.
 
-1. Install ImageMagick package:
+1. Install img2pdf package :
     ```shell
-    sudo apt-get install imagemagick
+    sudo apt-get install img2pdf
     ```
 2. If you want the PDF to be OCRed (recognize the text in it and make it searchable), install the OCRmyPDF package:
     ```shell

--- a/convert-images-to-pdf.sh
+++ b/convert-images-to-pdf.sh
@@ -32,9 +32,9 @@ if [[ ! -d $image_directory ]]; then
   exit 1
 fi
 
-# Check if 'convert' commands exist
-if ! command -v convert &>/dev/null; then
-  echo "Error: 'convert' command not found. Install ImageMagick package and re-run this script."
+# Check if 'img2pdf' command exists
+if ! command -v img2pdf &>/dev/null; then
+  echo "Error: 'img2pdf' command not found. Install it (e.g., sudo apt install img2pdf) and re-run this script."
   exit 1
 fi
 
@@ -42,9 +42,9 @@ fi
 (
   cd "$image_directory"
 
-  # Convert images to PDF
-  echo "Converting images to PDF..."
-  convert $(ls -1v *.jpg *.jpeg *.png 2>/dev/null | tr '\n' ' ') "$output_pdf"
+  # Convert images to PDF natively without re-encoding
+  echo "Converting images to PDF using img2pdf..."
+  img2pdf $(ls -1v *.jpg *.jpeg *.png 2>/dev/null) -o "$output_pdf"
 
   # Optionally OCR the PDF
   if command -v ocrmypdf &>/dev/null; then


### PR DESCRIPTION
**Description:**
This PR fixes an issue where the generated PDF has distorted or horizontally triplicated pages.

**Cause:**
The images downloaded from doc88 sometimes contain corrupted or non-standard ICC color profiles. When ImageMagick (convert) processes these, it misinterprets the pixel data, leading to the "ICCBased space /N value" error and the visual distortion.

**Solution:**
Replaced ImageMagick with img2pdf. This tool performs a lossless conversion by natively wrapping the JPEG images into the PDF container without re-encoding them. This prevents the ICC profile bug, significantly improves performance, and reduces RAM usage.